### PR TITLE
Feature/final release

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -92,5 +92,7 @@
   "Offline.alert.description":
     "Your device is currently disconnected and we are unable to authenticate the logged in user. Please make sure you have a working internet connection to use this application.",
   "Authentication.phonenumber": "Phone number",
-  "Authentication.id": "ID"
+  "Authentication.id": "ID",
+  "Notification.event.button": "Show",
+  "Notification.event.text": "New event received"
 }

--- a/i18n/locales/he.json
+++ b/i18n/locales/he.json
@@ -90,5 +90,7 @@
   "Offline.alert.description":
     "המכשיר שלך מנותק כרגע ואיננו יכולים לאמת את המשתמש המחובר. ודא שיש לך חיבור לאינטרנט פעיל כדי להשתמש ביישום זה.",
   "Authentication.phonenumber": "מספר טלפון",
-  "Authentication.id": "ת.ז."
+  "Authentication.id": "ת.ז.",
+  "Notification.event.button": "לראות",
+  "Notification.event.text": "התקבל אירוע חדש"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yedidim-volunteer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "devDependencies": {
     "babel-eslint": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yedidim-volunteer",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "devDependencies": {
     "babel-eslint": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yedidim-volunteer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "devDependencies": {
     "babel-eslint": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yedidim-volunteer",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "devDependencies": {
     "babel-eslint": "^8.0.1",

--- a/src/Main.js
+++ b/src/Main.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import EmailPassAuthenticationScreen from 'screens/Authentication/EmailPass'
+import PhoneAuthScreen from 'screens/Authentication/Phone'
 import { inject, observer } from 'mobx-react/native'
 import { Root, Toast } from 'native-base'
 import { Alert } from 'react-native'
@@ -81,7 +81,7 @@ class Main extends Component {
         {isAuthenticated ? (
           <AuthenticatedDrawer screenProps={screenProps} />
         ) : (
-          <EmailPassAuthenticationScreen />
+          <PhoneAuthScreen />
         )}
         {isLoading && <LoadingMask />}
       </Root>

--- a/src/Main.js
+++ b/src/Main.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import PhoneAuthenticationScreen from 'screens/Authentication/Phone'
 import EmailPassAuthenticationScreen from 'screens/Authentication/EmailPass'
 import { inject, observer } from 'mobx-react/native'
 import { Root, Toast } from 'native-base'
@@ -7,7 +6,6 @@ import { Alert } from 'react-native'
 import { injectIntl, defineMessages } from 'react-intl'
 import AuthenticatedDrawer from 'layouts/AuthenticatedDrawer'
 import LoadingMask from 'components/LoadingMask'
-import { Constants } from 'expo'
 
 const offline = defineMessages({
   title: {
@@ -78,17 +76,12 @@ class Main extends Component {
   render() {
     const { isAuthenticated, isLoading, ...screenProps } = this.props
 
-    const AuthenticationScreen =
-      Constants.platform && Constants.platform.ios
-        ? PhoneAuthenticationScreen
-        : EmailPassAuthenticationScreen
-
     return (
       <Root>
         {isAuthenticated ? (
           <AuthenticatedDrawer screenProps={screenProps} />
         ) : (
-          <AuthenticationScreen />
+          <EmailPassAuthenticationScreen />
         )}
         {isLoading && <LoadingMask />}
       </Root>

--- a/src/Main.js
+++ b/src/Main.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import PhoneAuthScreen from 'screens/Authentication/Phone'
+import EmailPassAuthenticationScreen from 'screens/Authentication/EmailPass'
 import { inject, observer } from 'mobx-react/native'
 import { Root, Toast } from 'native-base'
 import { Alert } from 'react-native'
@@ -81,7 +81,7 @@ class Main extends Component {
         {isAuthenticated ? (
           <AuthenticatedDrawer screenProps={screenProps} />
         ) : (
-          <PhoneAuthScreen />
+          <EmailPassAuthenticationScreen />
         )}
         {isLoading && <LoadingMask />}
       </Root>

--- a/src/components/NotificationManager.js
+++ b/src/components/NotificationManager.js
@@ -4,7 +4,7 @@ import { reaction } from 'mobx'
 import { Notifications } from 'expo'
 import { Toast } from 'native-base'
 import { NavigationActions } from 'react-navigation'
-import { defineMessages, injectIntl } from 'react-intl'
+import { defineMessages } from 'react-intl'
 
 const newEventToast = defineMessages({
   button: {
@@ -95,9 +95,11 @@ const withNotificationManager = WrappedComponent => {
         if (origin === 'received') {
           // The app if foregrounded
           Toast.show({
-            text: this.props.intl.formatMessage(newEventToast.text),
+            text: this.props.screenProps.intl.formatMessage(newEventToast.text),
             position: 'bottom',
-            buttonText: this.props.intl.formatMessage(newEventToast.button),
+            buttonText: this.props.screenProps.intl.formatMessage(
+              newEventToast.button
+            ),
             type: 'warning',
             // duration: 10000,
             onClose: () => this.navigateToEvent({ eventId: key })
@@ -110,12 +112,7 @@ const withNotificationManager = WrappedComponent => {
     }
 
     render() {
-      const {
-        currentUser,
-        addEventFromNotification,
-        intl,
-        ...other
-      } = this.props
+      const { currentUser, addEventFromNotification, ...other } = this.props
 
       return <WrappedComponent {...other} />
     }
@@ -124,12 +121,10 @@ const withNotificationManager = WrappedComponent => {
   // As described at https://github.com/react-community/react-navigation/issues/90
   Component.router = WrappedComponent.router
 
-  return injectIntl(
-    inject(({ stores }) => ({
-      addEventFromNotification: stores.eventStore.addEventFromNotification,
-      currentUser: stores.authStore.currentUser
-    }))(observer(Component))
-  )
+  return inject(({ stores }) => ({
+    addEventFromNotification: stores.eventStore.addEventFromNotification,
+    currentUser: stores.authStore.currentUser
+  }))(observer(Component))
 }
 
 export default withNotificationManager

--- a/src/components/NotificationManager.js
+++ b/src/components/NotificationManager.js
@@ -4,6 +4,18 @@ import { reaction } from 'mobx'
 import { Notifications } from 'expo'
 import { Toast } from 'native-base'
 import { NavigationActions } from 'react-navigation'
+import { defineMessages, injectIntl } from 'react-intl'
+
+const newEventToast = defineMessages({
+  button: {
+    id: 'Notification.event.button',
+    defaultMessage: 'Show'
+  },
+  text: {
+    id: 'Notification.event.text',
+    defaultMessage: 'New event received'
+  }
+})
 
 const withNotificationManager = WrappedComponent => {
   const Component = class extends React.Component {
@@ -83,9 +95,9 @@ const withNotificationManager = WrappedComponent => {
         if (origin === 'received') {
           // The app if foregrounded
           Toast.show({
-            text: 'New event received',
+            text: this.props.intl.formatMessage(newEventToast.text),
             position: 'bottom',
-            buttonText: 'Show',
+            buttonText: this.props.intl.formatMessage(newEventToast.button),
             type: 'warning',
             // duration: 10000,
             onClose: () => this.navigateToEvent({ eventId: key })
@@ -107,10 +119,12 @@ const withNotificationManager = WrappedComponent => {
   // As described at https://github.com/react-community/react-navigation/issues/90
   Component.router = WrappedComponent.router
 
-  return inject(({ stores }) => ({
-    addEventFromNotification: stores.eventStore.addEventFromNotification,
-    currentUser: stores.authStore.currentUser
-  }))(observer(Component))
+  return injectIntl(
+    inject(({ stores }) => ({
+      addEventFromNotification: stores.eventStore.addEventFromNotification,
+      currentUser: stores.authStore.currentUser
+    }))(observer(Component))
+  )
 }
 
 export default withNotificationManager

--- a/src/components/NotificationManager.js
+++ b/src/components/NotificationManager.js
@@ -110,7 +110,12 @@ const withNotificationManager = WrappedComponent => {
     }
 
     render() {
-      const { currentUser, addEventFromNotification, ...other } = this.props
+      const {
+        currentUser,
+        addEventFromNotification,
+        intl,
+        ...other
+      } = this.props
 
       return <WrappedComponent {...other} />
     }

--- a/src/io/analytics.js
+++ b/src/io/analytics.js
@@ -1,10 +1,10 @@
-import { Amplitude, Constants } from 'expo'
-
+// import { Amplitude, Constants } from 'expo'
+// Disabled Amplitude due to issues with Android
 export const initAnalyticsTracking = () => {
-  Amplitude.initialize(Constants.manifest.extra.AmplitudeAPI)
+  // Amplitude.initialize(Constants.manifest.extra.AmplitudeAPI)
 }
 
-export const trackUserLogin = userId => Amplitude.setUserId(userId)
+export const trackUserLogin = userId => {} // Amplitude.setUserId(userId)
 
-export const trackEvent = (eventName, properties) =>
-  Amplitude.logEventWithProperties(eventName, properties)
+export const trackEvent = (eventName, properties) => {}
+// Amplitude.logEventWithProperties(eventName, properties)

--- a/src/io/api.js
+++ b/src/io/api.js
@@ -163,6 +163,32 @@ const eventSnapshotToJSON = snapshot => ({
   phone: snapshot.details['phone number']
 })
 
+export async function loadLatestOpenEvents() {
+  return new Promise((resolve, reject) => {
+    try {
+      const events = []
+
+      firebase
+        .database()
+        .ref('events')
+        .orderByChild('status')
+        .equalTo('sent')
+        .once('value', snapshot => {
+          Object.values(snapshot.val())
+            .sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1))
+            .slice(0, 25)
+            .forEach(childSnapshot => {
+              events.push(eventSnapshotToJSON(childSnapshot))
+            })
+
+          resolve(events)
+        })
+    } catch (error) {
+      reject(error)
+    }
+  })
+}
+
 export function subscribeToEvent(eventKey, onChangeCallback) {
   const callback = snapshot => {
     if (snapshot && snapshot.val()) {

--- a/src/io/storage.js
+++ b/src/io/storage.js
@@ -1,35 +1,7 @@
 import { AsyncStorage } from 'react-native'
 import { defaultLanguage, environment } from 'config'
 
-const EVENTS_STORAGE_KEY = `@YedidimNative:events:${environment()}`
 const LANGUAGE_STORAGE_KEY = `@YedidimNative:language:${environment()}`
-
-export async function eventIds() {
-  const serialEvents = await AsyncStorage.getItem(EVENTS_STORAGE_KEY)
-  if (!serialEvents) {
-    // Set initial value, if not present
-    await AsyncStorage.setItem(EVENTS_STORAGE_KEY, JSON.stringify({}))
-    return []
-  }
-  // Parse existing and return keys
-  return Object.keys(JSON.parse(serialEvents))
-}
-
-export async function addEventId(eventId) {
-  const newEvent = {}
-  newEvent[eventId] = true
-  return AsyncStorage.mergeItem(EVENTS_STORAGE_KEY, JSON.stringify(newEvent))
-}
-
-export async function removeEventId(eventId) {
-  const events = JSON.parse(await AsyncStorage.getItem(EVENTS_STORAGE_KEY))
-  delete events[eventId]
-  return AsyncStorage.setItem(EVENTS_STORAGE_KEY, JSON.stringify(events))
-}
-
-export async function clear() {
-  return AsyncStorage.setItem(EVENTS_STORAGE_KEY, JSON.stringify({}))
-}
 
 export async function getLanguage() {
   return (await AsyncStorage.getItem(LANGUAGE_STORAGE_KEY)) || defaultLanguage()

--- a/src/screens/Authentication/EmailPass.js
+++ b/src/screens/Authentication/EmailPass.js
@@ -28,18 +28,6 @@ const IntroText = styled.Text`
   font-size: 16px;
 `
 
-const ButtonsView = styled.View`
-  flex-direction: row;
-  margin-top: 40px;
-`
-
-const StyledButton = styled(Button)`
-  flex-grow: 1;
-  align-content: center;
-  justify-content: center;
-  margin: 0 5px;
-`
-
 const ErrorText = styled.Text`
   text-align: center;
   color: red;
@@ -74,7 +62,7 @@ class EmailPassAuthenticationScreen extends React.Component {
           </Body>
           <Right />
         </Header>
-        <Content>
+        <Content style={{ flex: 1 }}>
           {authError ? (
             <View>
               <FormattedMessage
@@ -108,7 +96,7 @@ class EmailPassAuthenticationScreen extends React.Component {
                 onChangeText={value => this.setState({ phoneNumber: value })}
               />
             </Item>
-            <Item floatingLabel last>
+            <Item floatingLabel>
               <Label style={{ textAlign: 'left' }}>
                 <FormattedMessage id="Authentication.id" defaultMessage="ID">
                   {txt => txt}
@@ -119,25 +107,25 @@ class EmailPassAuthenticationScreen extends React.Component {
                 onChangeText={value => this.setState({ id: value })}
               />
             </Item>
-            <ButtonsView>
-              <StyledButton
-                iconLeft
-                full
-                large
-                block
-                onPress={this.handleAuthentication}
-              >
-                <Icon style={{ fontSize: 40 }} name="ios-person" />
-                <FormattedMessage
-                  id="Authentication.button"
-                  defaultMessage="Authenticate me"
-                >
-                  {txt => <Text>{txt}</Text>}
-                </FormattedMessage>
-              </StyledButton>
-            </ButtonsView>
           </Form>
         </Content>
+        <Button
+          style={{ height: 70 }}
+          iconLeft
+          full
+          large
+          block
+          success
+          onPress={this.handleAuthentication}
+        >
+          <Icon style={{ fontSize: 40 }} name="ios-person" />
+          <FormattedMessage
+            id="Authentication.button"
+            defaultMessage="Authenticate me"
+          >
+            {txt => <Text>{txt}</Text>}
+          </FormattedMessage>
+        </Button>
       </Container>
     )
   }

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -140,6 +140,10 @@ class HomeScreen extends Component {
     )
   })
 
+  componentWillMount() {
+    this.props.loadLatestOpenEvents()
+  }
+
   handleEventItemPress = debounce(
     eventId => {
       trackEvent('Navigation', { page: 'EventPage', eventId })
@@ -181,5 +185,6 @@ class HomeScreen extends Component {
 export default inject(({ stores }) => ({
   currentUser: stores.authStore.currentUser,
   hasEvents: stores.eventStore.hasEvents,
-  allEvents: stores.eventStore.allEvents
+  allEvents: stores.eventStore.allEvents,
+  loadLatestOpenEvents: stores.eventStore.loadLatestOpenEvents
 }))(HomeScreen)

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -65,7 +65,7 @@ const EventItem = observer(
         }}
       >
         <Left>
-          <Thumbnail source={eventTypeImg(type)} />
+          <Thumbnail small source={eventTypeImg(type)} />
         </Left>
         <Body>
           <FormattedMessage {...eventTypeMessage(type)}>

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -17,7 +17,7 @@ import {
   ListItem,
   Thumbnail
 } from 'native-base'
-import { ActivityIndicator } from 'react-native'
+import { ActivityIndicator, RefreshControl } from 'react-native'
 import { eventTypeMessage, eventTypeImg } from 'const'
 import debounce from 'lodash.debounce'
 import { trackEvent } from 'io/analytics'
@@ -140,8 +140,12 @@ class HomeScreen extends Component {
     )
   })
 
+  state = {
+    refreshing: false
+  }
+
   componentWillMount() {
-    this.props.loadLatestOpenEvents()
+    this.handleRefresh()
   }
 
   handleEventItemPress = debounce(
@@ -153,29 +157,46 @@ class HomeScreen extends Component {
     { leading: true, trailing: false }
   )
 
+  handleRefresh = async () => {
+    this.setState(() => ({ refreshing: true }))
+    await this.props.loadLatestOpenEvents()
+    this.setState(() => ({ refreshing: false }))
+  }
+
   render() {
     const { hasEvents, allEvents } = this.props
+    const { refreshing } = this.state
 
     return (
       <Container>
-        <Content style={{ backgroundColor: '#fff' }}>
-          {hasEvents ? (
+        <Content
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={this.handleRefresh}
+            />
+          }
+          style={{ backgroundColor: '#fff' }}
+        >
+          {hasEvents && (
             <List
               dataArray={allEvents}
               renderRow={event => (
                 <EventItem event={event} onPress={this.handleEventItemPress} />
               )}
             />
-          ) : (
-            <MessageView>
-              <FormattedMessage
-                id="Home.noevents"
-                defaultMessage="Sorry, no events were found"
-              >
-                {txt => <Text>{txt}</Text>}
-              </FormattedMessage>
-            </MessageView>
           )}
+          {!hasEvents &&
+            !refreshing && (
+              <MessageView>
+                <FormattedMessage
+                  id="Home.noevents"
+                  defaultMessage="Sorry, no events were found"
+                >
+                  {txt => <Text>{txt}</Text>}
+                </FormattedMessage>
+              </MessageView>
+            )}
         </Content>
       </Container>
     )

--- a/src/screens/SideBar.js
+++ b/src/screens/SideBar.js
@@ -3,18 +3,13 @@ import { Constants } from 'expo'
 import { Text, Container, List, ListItem, Content } from 'native-base'
 import { Image } from 'react-native'
 import { inject, observer } from 'mobx-react/native'
-import { environment } from 'config'
 import { FormattedMessage } from 'react-intl'
 import { NavigationActions } from 'react-navigation'
 import Logo from './logo.png'
 
-const isDevMode = () => environment() === 'development'
-
 const SideBar = ({
   signOut,
   currentUser: { name, phone },
-  addEventFromNotification,
-  removeEvent,
   nextLanguage,
   toggleLanguage,
   navigation
@@ -76,26 +71,6 @@ const SideBar = ({
         <ListItem>
           <Text>v{Constants.manifest.version}</Text>
         </ListItem>
-        {isDevMode() && (
-          <ListItem
-            button
-            onPress={() => {
-              addEventFromNotification('-L1y19rZZGK6p91r9ByU')
-            }}
-          >
-            <Text>DEBUG: New Event AsyncStorage</Text>
-          </ListItem>
-        )}
-        {isDevMode() && (
-          <ListItem
-            button
-            onPress={() => {
-              removeEvent('-L1y19rZZGK6p91r9ByU')
-            }}
-          >
-            <Text>DEBUG: Remove Sample Event</Text>
-          </ListItem>
-        )}
       </List>
     </Content>
   </Container>
@@ -104,8 +79,6 @@ const SideBar = ({
 export default inject(({ stores }) => ({
   signOut: stores.authStore.signOut,
   currentUser: stores.authStore.currentUser,
-  addEventFromNotification: stores.eventStore.addEventFromNotification,
-  removeEvent: stores.eventStore.removeEvent,
   nextLanguage: stores.nextLanguage,
   toggleLanguage: stores.toggleLanguage
 }))(observer(SideBar))

--- a/src/stores/Event.js
+++ b/src/stores/Event.js
@@ -109,7 +109,10 @@ const EventStore = types
       return self.events.get(eventId)
     },
     get allEvents() {
-      return self.events.values()
+      // Latest events sorted by timestamp
+      return self.events
+        .values()
+        .sort((e1, e2) => (e1.timestamp > e2.timestamp ? -1 : 1))
     },
     get hasEvents() {
       return self.events.size > 0
@@ -125,7 +128,6 @@ const EventStore = types
 
     return {
       loadLatestOpenEvents: flow(function* loadLatestOpenEvents() {
-        self.removeAllEvents()
         const events = yield api.loadLatestOpenEvents()
         events.forEach(addEvent)
       }),

--- a/src/stores/Event.js
+++ b/src/stores/Event.js
@@ -17,7 +17,7 @@ export const Event = types
     status: types.maybe(types.string),
     assignedTo: types.maybe(types.string),
     timestamp: types.maybe(types.Date),
-    isLoading: true
+    isLoading: false
   })
   .views(self => ({
     get store() {
@@ -48,6 +48,11 @@ export const Event = types
       self.isLoading = false
     },
     afterCreate: () => {
+      // If no data is provided with event, set it as loading
+      if (!self.address || !self.type) {
+        self.isLoading = true
+      }
+
       self.unsubscribeId = api.subscribeToEvent(self.id, self.onEventUpdated)
     },
     beforeDestroy: () => {


### PR DESCRIPTION
- Working on Android with Email+Password Authentication (Phone+ID) 
- Removed Amplitude which was causing issues in Android
- Same authentication scheme for iOS and Android (Email/Password)
- Home screen with fixed latest 25 open events that are updated in real time, list can be refreshed by a "pul-to-refresh" movement in the list
- Small UI adjustments