### PR TITLE
Bug/empty events crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yedidim-volunteer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "devDependencies": {
     "babel-eslint": "^8.0.1",

--- a/src/io/api.js
+++ b/src/io/api.js
@@ -114,7 +114,10 @@ export async function signInWithPhone({ verificationId, code }) {
 export async function signInWithEmailPass({ phoneNumber, id }) {
   try {
     // TODO Support other countries ?
-    const userId = `+972${phoneNumber.replace(/^0/, '')}`
+    const userId = `+972${phoneNumber
+      .trim()
+      .replace(/^0/, '')
+      .replace(/-/, '')}`
 
     await firebase
       .auth()

--- a/src/io/api.js
+++ b/src/io/api.js
@@ -117,7 +117,7 @@ export async function signInWithEmailPass({ phoneNumber, id }) {
     const userId = `+972${phoneNumber
       .trim()
       .replace(/^0/, '')
-      .replace(/-/, '')}`
+      .replace(/-/g, '')}`
 
     await firebase
       .auth()

--- a/src/io/api.js
+++ b/src/io/api.js
@@ -174,7 +174,7 @@ export async function loadLatestOpenEvents() {
         .orderByChild('status')
         .equalTo('sent')
         .once('value', snapshot => {
-          Object.values(snapshot.val())
+          Object.values(snapshot.val() || [])
             .sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1))
             .slice(0, 25)
             .forEach(childSnapshot => {

--- a/src/screens/Authentication/EmailPass.js
+++ b/src/screens/Authentication/EmailPass.js
@@ -20,6 +20,7 @@ import styled from 'styled-components/native'
 import { inject, observer } from 'mobx-react/native'
 import { FormattedMessage } from 'react-intl'
 import { trackEvent } from 'io/analytics'
+import { Constants } from 'expo'
 
 const IntroText = styled.Text`
   text-align: center;
@@ -33,6 +34,11 @@ const ErrorText = styled.Text`
   color: red;
   font-weight: bold;
   margin-bottom: 10px;
+`
+
+const VersionText = styled.Text`
+  text-align: center;
+  font-weight: bold;
 `
 
 @observer
@@ -81,6 +87,7 @@ class EmailPassAuthenticationScreen extends React.Component {
               {txt => <IntroText>{txt}</IntroText>}
             </FormattedMessage>
           )}
+          <VersionText>v{Constants.manifest.version}</VersionText>
           <Form>
             <Item floatingLabel>
               <Label style={{ textAlign: 'left' }}>


### PR DESCRIPTION
- Avoid crashing when list of events is empty
- Add version number to the authentication screen
- Process phone number to clean it from dashes and whitespaces