### PR TITLE
fix: update list order when event status changes

### DIFF
--- a/src/stores/Event.js
+++ b/src/stores/Event.js
@@ -133,7 +133,7 @@ const EventStore = types
       return self.events.size > 0
     },
     get sortedEventsByStatusAndTimestamp() {
-      return self.allEvents.sort((a, b) => {
+      return self.allEvents.slice().sort((a, b) => {
         if (a.isTaken === b.isTaken) {
           return a.timestamp - b.timestamp
         }


### PR DESCRIPTION
used slice to copy list of events before performing sorting, this fixes the issue with the list not updating the order when the status changes